### PR TITLE
Improve run script robustness

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -12,7 +12,6 @@ if [ $1 = "train" ] ; then
    sleep 2
    cd web/main
    xterm -geometry 80x20 -T "SimpleDS.Client" -hold -e "node runclient.js train"
-   #node runclient.js train
    cd ../../
 
 elif [ $1 = "test" ] ; then 
@@ -20,7 +19,6 @@ elif [ $1 = "test" ] ; then
    sleep 2
    cd web/main
    xterm -geometry 80x20 -T "SimpleDS.Client" -hold -e "node runclient.js test"
-   #node runclient.js test
    cd ../../
 
 else 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -7,21 +7,27 @@
 
 stty cols 120
 
+# Parent/Root directory relative to this script.
+# Allows this to be called from any working directoy and still function.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
+pushd $DIR
+
 if [ $1 = "train" ] ; then
    xterm -geometry 120x50 -T "SimpleDS.Server" -hold -e "ant SimpleDS" &
    sleep 2
-   cd web/main
+   pushd $DIR/web/main/
    xterm -geometry 80x20 -T "SimpleDS.Client" -hold -e "node runclient.js train"
-   cd ../../
+   popd
 
 elif [ $1 = "test" ] ; then 
    xterm -geometry 120x50 -T "SimpleDS.Client" -hold -e "ant SimpleDS" &
    sleep 2
-   cd web/main
+   pushd $DIR/web/main/
    xterm -geometry 80x20 -T "SimpleDS.Client" -hold -e "node runclient.js test"
-   cd ../../
+   popd
 
 else 
    echo "usage: run.sh (train | test)" 
-fi 
+fi
 
+popd

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -12,14 +12,14 @@ stty cols 120
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
 pushd $DIR
 
-if [ $1 = "train" ] ; then
+if [ "$1" = "train" ] ; then
    xterm -geometry 120x50 -T "SimpleDS.Server" -hold -e "ant SimpleDS" &
    sleep 2
    pushd $DIR/web/main/
    xterm -geometry 80x20 -T "SimpleDS.Client" -hold -e "node runclient.js train"
    popd
 
-elif [ $1 = "test" ] ; then 
+elif [ "$1" = "test" ] ; then 
    xterm -geometry 120x50 -T "SimpleDS.Client" -hold -e "ant SimpleDS" &
    sleep 2
    pushd $DIR/web/main/

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #################################################################################### 
 # This script runs the SimpleDS system for training dialogue agents 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -10,21 +10,21 @@ stty cols 120
 # Parent/Root directory relative to this script.
 # Allows this to be called from any working directoy and still function.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
-pushd $DIR
+pushd $DIR > /dev/null
 
 if [ "$1" = "train" ] ; then
    xterm -geometry 120x50 -T "SimpleDS.Server" -hold -e "ant SimpleDS" &
    sleep 2
-   pushd $DIR/web/main/
+   pushd $DIR/web/main/ > /dev/null
    xterm -geometry 80x20 -T "SimpleDS.Client" -hold -e "node runclient.js train"
-   popd
+   popd > /dev/null
 
 elif [ "$1" = "test" ] ; then 
    xterm -geometry 120x50 -T "SimpleDS.Client" -hold -e "ant SimpleDS" &
    sleep 2
-   pushd $DIR/web/main/
+   pushd $DIR/web/main/ > /dev/null
    xterm -geometry 80x20 -T "SimpleDS.Client" -hold -e "node runclient.js test"
-   popd
+   popd > /dev/null
 
 else 
    echo "usage: run.sh (train | test)" 


### PR DESCRIPTION
Improvements to the run script to allow it to be called from any active directory, and still function as expected.
Fixed error where `run.sh` (without args) would cause an issue with syntax as $1 would be substituted to nothing.
Removed additional commented commands.
